### PR TITLE
[MJAR-254] Adjust integration test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -181,8 +181,6 @@
                 <goal>clean</goal>
                 <goal>package</goal>
               </goals>
-              <streamLogs>true</streamLogs>
-              <showErrors>true</showErrors>
             </configuration>
             <executions>
               <execution>

--- a/src/it/MJAR-254/invoker.properties
+++ b/src/it/MJAR-254/invoker.properties
@@ -15,8 +15,4 @@
 # specific language governing permissions and limitations
 # under the License.
 
-invoker.goals = clean install install:install-file
-
-#  -Dfile=target/executable1.jar \
-# -DgroupId=org.apache.maven.its.jars -DartifactId=executable1 -Dversion=1.0-SNAPSHOT \
-# -Dpackaging=jar
+invoker.goals = install

--- a/src/it/MJAR-254/pom.xml
+++ b/src/it/MJAR-254/pom.xml
@@ -82,44 +82,6 @@
                     </execution>
                 </executions>
             </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-install-plugin</artifactId>
-                <version>2.5.2</version>
-                <configuration>
-                    <file>target/${build.finalName}.jar</file>
-                </configuration>
-                <executions>
-                    <execution>
-                        <id>install-executable1</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>${project.groupId}</groupId>
-                            <artifactId>executable1</artifactId>
-                            <version>${project.version}</version>
-                            <file>target/executable1.jar</file>
-                            <packaging>jar</packaging>
-                        </configuration>
-                    </execution>
-                    <execution>
-                        <id>install-executable2</id>
-                        <phase>package</phase>
-                        <goals>
-                            <goal>install-file</goal>
-                        </goals>
-                        <configuration>
-                            <groupId>${project.groupId}</groupId>
-                            <artifactId>executable2</artifactId>
-                            <version>${project.version}</version>
-                            <file>target/executable2.jar</file>
-                            <packaging>jar</packaging>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
         </plugins>
     </build>
 </project>

--- a/src/it/MJAR-254/verify.groovy
+++ b/src/it/MJAR-254/verify.groovy
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+def log = new File( basedir, 'build.log').text
+
+def mainJar = new File( localRepositoryPath, "org/apache/maven/its/jars/mjar254/1.0-SNAPSHOT/mjar254-1.0-SNAPSHOT.jar" )
+assert mainJar.exists()
+
+def mainJarArchiver = new java.util.jar.JarFile( mainJar )
+assert mainJarArchiver.getJarEntry( "META-INF/MANIFEST.MF" )
+
+def classifiedJar = new File( localRepositoryPath, "org/apache/maven/its/jars/mjar254/1.0-SNAPSHOT/mjar254-1.0-SNAPSHOT-test.jar" )
+assert classifiedJar.exists()
+
+def classifiedJarArchiver = new java.util.jar.JarFile( classifiedJar )
+assert  classifiedJarArchiver.getJarEntry( "META-INF/MANIFEST.MF" )


### PR DESCRIPTION
I've changed the integration test.
What I'd like to see is that you replace the `META_INF/MANIFEST.MF` check for the entries you do expect in the jar files.